### PR TITLE
Switch to native a HomeAssistant DataUpdateCoordinator for the sensor values, allow update interval to be configured

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -100,7 +100,13 @@ async def async_setup_platform(
                 return data
 
             except franklinwh.client.DeviceTimeoutException as e:
-                _LOGGER.warning("Timeout getting data from FranklinWH: %s", e)
+                _LOGGER.warning("Error getting data from FranklinWH - Device Timeout: %s", e)
+            except franklinwh.client.GatewayOfflineException as e:
+                _LOGGER.warning("Error getting data from FranklinWH - Gateway Offline %s", e)
+            except franklinwh.client.AccountLockedException as e:
+                _LOGGER.warning("Error getting data from FranklinWH - Account Locked %s", e)
+            except franklinwh.client.InvalidCredentialsException as e:
+                _LOGGER.warning("Error getting data from FranklinWH - Invalid Credentials %s", e)
 
         _LOGGER.warning(f"Failed to fetch data from FranklinWH after {max_retries} attempts.")
         raise UpdateFailed(f"Failed to fetch data from FranklinWH after {max_retries} attempts.")


### PR DESCRIPTION
This patch replaces the use of `ThreadedCachingClient` with a ’native’ Home Assistant `DataUpdateCoordinator`, and makes the update interval configurable.

Rationale: 

I wanted to use (and am now using!) Home Assistant to poll my FranklinWH system for power stats, and feed them via MQTT to my OpenEVSE car charger, allowing it to divert excess solar production - usually sent to the grid - to my car.

To do this, I needed to increase the polling frequency - but the update frequency of the `ThreadedCachingClient` was not configurable. 

As a secondary concern, I believe that when using the `ThreadedCachingClient`, the polling was not ‘connected’ to Home Assistant: the cache updated itself on its own schedule, and Home Assistant polled the cache on _its_ own schedule, so that the information received by Home Assistant could be out of date by (worst case) almost (cache_poll_period + home_assistant_poll_period). That would be bad for accurate charge diversion in variable cloudy days.

Switching to `DataUpdateCoordinator` solves both these problems (and, hopefully as a bonus, it’s also more Home-Assistant-idiomatic).
