### PR TITLE
Add select and number platforms for operating mode and export control

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ This is a custom integration for [Home Assistant](https://www.home-assistant.io/
 - Generator and home load insights
 - Switch load and usage tracking
 - Support for V2L (Vehicle-to-Load) data
+- **Operating mode control** (Self Consumption / Time of Use / Emergency Backup)
+- **Grid export mode control** (Solar Only / Solar + Battery / No Export)
+- **Grid export power limit** (kW cap on grid feed)
 
 ---
 
@@ -55,7 +58,22 @@ sensor:
     password: !secret franklinwh_password
     id: "100xxxxxxxxxxxx"
     tolerate_stale_data: true
+
+select:
+  - platform: franklin_wh
+    username: "email@domain.com"
+    password: !secret franklinwh_password
+    id: "100xxxxxxxxxxxx"
+
+number:
+  - platform: franklin_wh
+    username: "email@domain.com"
+    password: !secret franklinwh_password
+    id: "100xxxxxxxxxxxx"
+    max_export_kw: 10.0
 ```
+
+The `select` platform adds operating mode and export mode controls. The `number` platform adds the export power limit slider. Both are optional — omit them if you only need monitoring.
 
 The `tolerate_stale_data` key is not required, but is recommended. The
 FranklinWH API often fails to return valid data, that flag will persist the
@@ -91,16 +109,45 @@ switch:
     name: "FWH switch2"
 ```
 
+### Operating Mode and Export Control
+
+The integration can control the FranklinWH operating mode and grid export settings. These are polled every 5 minutes by default (modes change rarely).
+
+```yaml
+select:
+  - platform: franklin_wh
+    username: "email@domain.com"
+    password: !secret franklinwh_password
+    id: "100xxxxxxxxxxxx"
+
+number:
+  - platform: franklin_wh
+    username: "email@domain.com"
+    password: !secret franklinwh_password
+    id: "100xxxxxxxxxxxx"
+    max_export_kw: 10.0
+```
+
+This creates three entities:
+- **FranklinWH Operating Mode** — select between `self_consumption`, `time_of_use`, and `emergency_backup`. The current reserve SOC is read from the device and preserved when changing modes.
+- **FranklinWH Export Mode** — select between `solar_only`, `solar_and_apower`, and `no_export`. The current power limit is preserved when changing export mode.
+- **FranklinWH Export Limit** — set the maximum export power in kW. Setting to the configured maximum is treated as unlimited.
+
+> ⚠️ Grid export control requires your utility and FranklinWH plan to support grid export. Check the FranklinWH app before enabling `solar_and_apower`.
+
+> ℹ️ The FranklinWH API does not push updates to Home Assistant. Changes made in the FranklinWH app will be reflected in HA on the next poll cycle — up to 5 minutes by default. Lower `update_interval` in your config if you need faster sync.
+
 After updating your configuration, restart Home Assistant to apply the changes.
 
 ### Advanced Configuration
 
-| Configuration Option         | Unit   | Description                                                               | sensor | switch |
-| ---------------------------- | ------ | --------------------------------------------------------------------------| ------ | ------ |
-| `use_sn`                     | bool   | Use the gateway's SN as a prefix when creating entities                   |  ✅    |   ✅   |
-| `prefix`                     | string | Specity a prefix to be used when creating entities                        |  ✅    |   ✅   |
-| `update_interval`            | time   | Period to update entities from franklinwh. Default 30s                    |  ✅    |   ✅   |
-| `tolerate_stale_data`        | bool   | Continue to show stale data on the dashboard for one cycle instead of showing the sensor unavailable                   |  ✅    |        |
+| Configuration Option         | Unit   | Description                                                               | sensor | switch | select | number |
+| ---------------------------- | ------ | --------------------------------------------------------------------------| ------ | ------ | ------ | ------ |
+| `use_sn`                     | bool   | Use the gateway's SN as a prefix when creating entities                   |  ✅    |   ✅   |   ✅   |   ✅   |
+| `prefix`                     | string | Specify a prefix to be used when creating entities                        |  ✅    |   ✅   |   ✅   |   ✅   |
+| `update_interval`            | time   | Update period. Default 30s (sensor/switch); 300s (select/number)          |  ✅    |   ✅   |   ✅   |   ✅   |
+| `tolerate_stale_data`        | bool   | Show stale data for one cycle instead of marking the sensor unavailable   |  ✅    |        |        |        |
+| `max_export_kw`              | float  | Maximum value (kW) for the export limit slider. Default 10.0              |        |        |        |   ✅   |
 
 
 ## Available Entities
@@ -127,6 +174,9 @@ After updating your configuration, restart Home Assistant to apply the changes.
 | FranklinWH V2L Use                  | Power use via Vehicle-to-Load             | W         |
 | FranklinWH V2L Import               | Total energy drawn from V2L               | Wh        |
 | FranklinWH V2L Export               | Total energy delivered to V2L             | Wh        |
+| FranklinWH Operating Mode           | Select operating mode (select platform)   | —         |
+| FranklinWH Export Mode              | Select grid export mode (select platform) | —         |
+| FranklinWH Export Limit             | Grid export power cap (number platform)   | kW        |
 
 # Flipping sensors
 

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_polling",
   "integration_type": "hub",
   "requirements": ["franklinwh==2026.3.*"],
-  "version": "2026.3.0",
+  "version": "2026.4.0",
   "issue_tracker": "https://github.com/richo/homeassistant-franklinwh/issues"
 }

--- a/number.py
+++ b/number.py
@@ -1,0 +1,194 @@
+"""Number platform for FranklinWH grid export power limit."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+import franklinwh
+import voluptuous as vol
+
+from homeassistant.components.number import (
+    PLATFORM_SCHEMA as NUMBER_PLATFORM_SCHEMA,
+    NumberEntity,
+    NumberMode,
+)
+from homeassistant.const import (
+    CONF_ID,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    UnitOfPower,
+)
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_UPDATE_INTERVAL = 300
+
+
+PLATFORM_SCHEMA = NUMBER_PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_ID): cv.string,
+        vol.Optional("use_sn", default=False): cv.boolean,
+        vol.Optional("prefix", default=False): cv.string,
+        vol.Optional(
+            "update_interval", default=DEFAULT_UPDATE_INTERVAL
+        ): cv.time_period,
+        vol.Optional("max_export_kw", default=10.0): vol.Coerce(float),
+    }
+)
+
+
+async def _read_export_settings(client) -> tuple[str, float | None]:
+    """Read the current grid export mode and limit from the API.
+
+    Returns (export_mode, limit_kw) where limit_kw is None for unlimited.
+    """
+    settings = await client.get_export_settings()
+    mode = settings.mode.name.lower()
+    return mode, settings.limit_kw
+
+
+async def _write_export_limit(client, limit_kw: float | None) -> None:
+    """Write the grid export power limit, preserving the current export mode."""
+    settings = await client.get_export_settings()
+    await client.set_export_settings(settings.mode, limit_kw)
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the number platform."""
+    username: str = config[CONF_USERNAME]
+    password: str = config[CONF_PASSWORD]
+    gateway: str = config[CONF_ID]
+    update_interval: timedelta = config["update_interval"]
+    max_export_kw: float = config["max_export_kw"]
+
+    # TODO(richo) why does it string the default value
+    if config["use_sn"] and config["use_sn"] != "False":
+        unique_id = gateway
+    else:
+        unique_id = None
+
+    # TODO(richo) why does it string the default value
+    if config["prefix"] and config["prefix"] != "False":
+        prefix = config["prefix"]
+    else:
+        prefix = "FranklinWH"
+
+    fetcher = franklinwh.TokenFetcher(username, password)
+    client = franklinwh.Client(fetcher, gateway)
+
+    async def _update_data() -> dict:
+        try:
+            export_mode, export_limit_kw = await _read_export_settings(client)
+            return {
+                "export_mode": export_mode,
+                "export_limit_kw": export_limit_kw,
+            }
+        except Exception as err:
+            raise UpdateFailed(
+                f"Error fetching FranklinWH export settings: {err}"
+            ) from err
+
+    coordinator = DataUpdateCoordinator[dict](
+        hass,
+        _LOGGER,
+        name="franklinwh_export_limit",
+        update_method=_update_data,
+        update_interval=update_interval,
+        always_update=False,
+    )
+
+    await coordinator.async_refresh()
+
+    async_add_entities(
+        [ExportLimitNumber(coordinator, prefix, unique_id, client, max_export_kw)]
+    )
+
+
+class ExportLimitNumber(
+    CoordinatorEntity[DataUpdateCoordinator[dict]], NumberEntity
+):
+    """Number entity for the FranklinWH grid export power limit.
+
+    Sets the maximum power (kW) that can be exported to the grid. A value
+    of 0 (or the entity being set to the max) with no active limit is
+    represented as None internally (unlimited). The export mode
+    (solar_only / solar_and_apower / no_export) is preserved when only
+    the limit is changed.
+    """
+
+    _attr_native_min_value = 0.0
+    _attr_native_step = 0.1
+    _attr_native_unit_of_measurement = UnitOfPower.KILO_WATT
+    _attr_mode = NumberMode.BOX
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[dict],
+        prefix: str,
+        unique_id: str | None,
+        client,
+        max_export_kw: float,
+    ) -> None:
+        """Initializer."""
+        super().__init__(coordinator)
+        self._attr_name = f"{prefix} Export Limit"
+        self._attr_native_max_value = max_export_kw
+        self._client = client
+        if unique_id:
+            self._attr_has_entity_name = True
+            self._attr_unique_id = unique_id + "_export_limit"
+
+    @property
+    def available(self) -> bool:
+        """Entity is available when the coordinator has data."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current export limit in kW.
+
+        Returns None (unknown) when the coordinator has no data, and
+        native_max_value when the device reports unlimited (-1 / None)
+        so the slider sits at the top of its range.
+        """
+        if not self.coordinator.data:
+            return None
+        limit = self.coordinator.data.get("export_limit_kw")
+        if limit is None:
+            # Unlimited — represent as the maximum slider value
+            return self._attr_native_max_value
+        return limit
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the export power limit.
+
+        A value at or above native_max_value is treated as unlimited
+        (passes None to the API, which stores -1 / no cap).
+        """
+        if value >= self._attr_native_max_value:
+            limit_kw = None  # unlimited
+        else:
+            limit_kw = value
+
+        await _write_export_limit(self._client, limit_kw)
+        await self.coordinator.async_refresh()

--- a/select.py
+++ b/select.py
@@ -1,0 +1,324 @@
+"""Select platform for FranklinWH operating mode and grid export control."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+import franklinwh
+import voluptuous as vol
+
+from homeassistant.components.select import (
+    PLATFORM_SCHEMA as SELECT_PLATFORM_SCHEMA,
+    SelectEntity,
+)
+from homeassistant.const import (
+    CONF_ID,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Poll mode/export status every 5 minutes — they rarely change
+DEFAULT_UPDATE_INTERVAL = 300
+
+_EXPORT_MODE_MAP = {
+    "solar_only": franklinwh.ExportMode.SOLAR_ONLY,
+    "solar_and_apower": franklinwh.ExportMode.SOLAR_AND_APOWER,
+    "no_export": franklinwh.ExportMode.NO_EXPORT,
+}
+
+# Correct runingMode values for current firmware (the library's built-in
+# MODE_MAP uses different keys and may not match all firmware versions)
+_RUNNING_MODE_MAP = {
+    7167: "self_consumption",
+    7168: "emergency_backup",
+    7169: "time_of_use",
+}
+
+OPERATING_MODES = ["self_consumption", "time_of_use", "emergency_backup"]
+EXPORT_MODES = ["solar_only", "solar_and_apower", "no_export"]
+
+PLATFORM_SCHEMA = SELECT_PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_ID): cv.string,
+        vol.Optional("use_sn", default=False): cv.boolean,
+        vol.Optional("prefix", default=False): cv.string,
+        vol.Optional(
+            "update_interval", default=DEFAULT_UPDATE_INTERVAL
+        ): cv.time_period,
+    }
+)
+
+
+async def _read_operating_mode(client) -> tuple[str | None, int | None]:
+    """Read the current operating mode and reserve SOC from the device.
+
+    Tries the high-level _status() endpoint (command 203) first, reading
+    the human-readable 'name' field which is firmware-version independent.
+    Falls back to _switch_status() (command 311) with numeric runingMode
+    lookup if the name field is absent or unrecognised.
+
+    Returns (mode_name, reserve_soc).
+    """
+    soc_key_map = {
+        "self_consumption": "selfMinSoc",
+        "time_of_use": "touMinSoc",
+        "emergency_backup": "backupMaxSoc",
+    }
+
+    # Primary: human-readable name from high-level status
+    try:
+        status = await client._status()
+        name = (status.get("name") or "").lower()
+        if "self" in name and "consumption" in name:
+            mode = "self_consumption"
+        elif "emergency" in name or "backup" in name:
+            mode = "emergency_backup"
+        elif "tou" in name or "time" in name:
+            mode = "time_of_use"
+        else:
+            mode = None
+
+        if mode:
+            sw = await client._switch_status()
+            reserve = sw.get(soc_key_map[mode])
+            return mode, reserve
+        if name:
+            _LOGGER.debug(
+                "get_mode: _status name %r unrecognised — trying _switch_status",
+                status.get("name"),
+            )
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug("get_mode: _status failed (%s) — trying _switch_status", err)
+
+    # Fallback: numeric runingMode
+    sw = await client._switch_status()
+    running_mode = sw.get("runingMode")
+    mode = _RUNNING_MODE_MAP.get(running_mode)
+    if mode is None:
+        _LOGGER.warning("get_mode: unrecognised runingMode %r", running_mode)
+    reserve = sw.get(soc_key_map[mode]) if mode else None
+    return mode, reserve
+
+
+async def _read_export_settings(client) -> tuple[str, float | None]:
+    """Read the current grid export mode and limit from the API.
+
+    Returns (export_mode, limit_kw) where limit_kw is None for unlimited.
+    """
+    settings = await client.get_export_settings()
+    mode = settings.mode.name.lower()
+    return mode, settings.limit_kw
+
+
+async def _write_export_settings(
+    client, mode: str, limit_kw: float | None
+) -> None:
+    """Write the grid export mode and optional power limit to the API."""
+    await client.set_export_settings(_EXPORT_MODE_MAP[mode], limit_kw)
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the select platform."""
+    username: str = config[CONF_USERNAME]
+    password: str = config[CONF_PASSWORD]
+    gateway: str = config[CONF_ID]
+    update_interval: timedelta = config["update_interval"]
+
+    # TODO(richo) why does it string the default value
+    if config["use_sn"] and config["use_sn"] != "False":
+        unique_id = gateway
+    else:
+        unique_id = None
+
+    # TODO(richo) why does it string the default value
+    if config["prefix"] and config["prefix"] != "False":
+        prefix = config["prefix"]
+    else:
+        prefix = "FranklinWH"
+
+    fetcher = franklinwh.TokenFetcher(username, password)
+    client = franklinwh.Client(fetcher, gateway)
+
+    async def _update_data() -> dict:
+        try:
+            operating_mode, reserve_soc = await _read_operating_mode(client)
+            export_mode, export_limit_kw = await _read_export_settings(client)
+            return {
+                "operating_mode": operating_mode,
+                "reserve_soc": reserve_soc,
+                "export_mode": export_mode,
+                "export_limit_kw": export_limit_kw,
+            }
+        except Exception as err:
+            raise UpdateFailed(f"Error fetching FranklinWH mode/export status: {err}") from err
+
+    coordinator = DataUpdateCoordinator[dict](
+        hass,
+        _LOGGER,
+        name="franklinwh_mode",
+        update_method=_update_data,
+        update_interval=update_interval,
+        always_update=False,
+    )
+
+    await coordinator.async_refresh()
+
+    async_add_entities(
+        [
+            OperatingModeSelect(coordinator, prefix, unique_id, client),
+            ExportModeSelect(coordinator, prefix, unique_id, client),
+        ]
+    )
+
+
+class FranklinSelectBase(
+    CoordinatorEntity[DataUpdateCoordinator[dict]], SelectEntity
+):
+    """Base class for FranklinWH select entities."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[dict],
+        prefix: str,
+        unique_id: str | None,
+        client,
+        name_suffix: str,
+        unique_id_suffix: str,
+    ) -> None:
+        """Initializer."""
+        super().__init__(coordinator)
+        self._attr_name = f"{prefix} {name_suffix}"
+        self._client = client
+        if unique_id:
+            self._attr_has_entity_name = True
+            self._attr_unique_id = unique_id + unique_id_suffix
+
+    @property
+    def available(self) -> bool:
+        """Entity is available when the coordinator has data."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+        )
+
+
+class OperatingModeSelect(FranklinSelectBase):
+    """Select entity for the FranklinWH operating mode.
+
+    Allows switching between Self Consumption, Time of Use, and Emergency
+    Backup directly from Home Assistant. The current reserve SOC is read
+    from the device and preserved when changing modes.
+    """
+
+    _attr_options = OPERATING_MODES
+
+    def __init__(self, coordinator, prefix, unique_id, client) -> None:
+        """Initializer."""
+        super().__init__(
+            coordinator,
+            prefix,
+            unique_id,
+            client,
+            "Operating Mode",
+            "_operating_mode",
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the currently active operating mode."""
+        if self.coordinator.data:
+            return self.coordinator.data.get("operating_mode")
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the operating mode, preserving the current reserve SOC."""
+        reserve_soc = (
+            self.coordinator.data.get("reserve_soc")
+            if self.coordinator.data
+            else None
+        )
+
+        if option == "emergency_backup":
+            soc = int(reserve_soc) if reserve_soc is not None else 100
+            mode = franklinwh.Mode.emergency_backup(soc=soc)
+        elif option == "self_consumption":
+            kwargs = {"soc": int(reserve_soc)} if reserve_soc is not None else {}
+            mode = franklinwh.Mode.self_consumption(**kwargs)
+        elif option == "time_of_use":
+            kwargs = {"soc": int(reserve_soc)} if reserve_soc is not None else {}
+            mode = franklinwh.Mode.time_of_use(**kwargs)
+        else:
+            _LOGGER.error("Unknown operating mode: %s", option)
+            return
+
+        await self._client.set_mode(mode)
+        # Optimistically update local state — the device takes a moment to
+        # apply the change so an immediate API read-back may not reflect it yet.
+        if self.coordinator.data is not None:
+            self.coordinator.data["operating_mode"] = option
+        self.async_write_ha_state()
+
+
+class ExportModeSelect(FranklinSelectBase):
+    """Select entity for the FranklinWH grid export mode.
+
+    Controls whether solar only, solar and battery, or no power is exported
+    to the grid. The current export power limit is preserved when changing
+    modes.
+    """
+
+    _attr_options = EXPORT_MODES
+
+    def __init__(self, coordinator, prefix, unique_id, client) -> None:
+        """Initializer."""
+        super().__init__(
+            coordinator,
+            prefix,
+            unique_id,
+            client,
+            "Export Mode",
+            "_export_mode",
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current grid export mode."""
+        if self.coordinator.data:
+            return self.coordinator.data.get("export_mode")
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the export mode, preserving the current power limit."""
+        if option not in _EXPORT_MODE_MAP:
+            _LOGGER.error("Unknown export mode: %s", option)
+            return
+
+        limit_kw = (
+            self.coordinator.data.get("export_limit_kw")
+            if self.coordinator.data
+            else None
+        )
+        await _write_export_settings(self._client, option, limit_kw)
+        # Optimistically update local state
+        if self.coordinator.data is not None:
+            self.coordinator.data["export_mode"] = option
+        self.async_write_ha_state()


### PR DESCRIPTION
## Summary

- Adds `select.py` with `OperatingModeSelect` (self_consumption / time_of_use / emergency_backup) and `ExportModeSelect` (solar_only / solar_and_apower / no_export)
- Adds `number.py` with `ExportLimitNumber` for setting the grid export power cap in kW
- Both platforms use `get_export_settings()` / `set_export_settings()` from `franklinwh==2026.3.*`
- Preserves reserve SOC when changing operating mode; preserves export limit when changing export mode
- Uses optimistic state updates so the selector doesn't go blank while the device applies the change
- Bumps version to `2026.4.0` and updates `manifest.json` to require `franklinwh==2026.3.*`
- Updates `README.md` with config examples, new entities, advanced config table, and polling delay note

## Test plan

- [x] Deployed to Home Assistant and tested against a live FranklinWH gateway
- [x] Operating mode change in HA reflects in FranklinWH app
- [x] Export mode change in HA reflects in FranklinWH app
- [x] Export limit slider works
- [x] Reserve SOC preserved across mode changes