### PR TITLE
Add operating mode select entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This is a custom integration for [Home Assistant](https://www.home-assistant.io/
 - Switch load and usage tracking
 - Support for V2L (Vehicle-to-Load) data
 - **Operating mode control** — switch between Time of Use, Self Consumption, and Emergency Backup
+- **Battery reserve control** — read and set per-mode reserve SOC percentages without changing operating mode
 
 ---
 
@@ -74,9 +75,6 @@ select:
     username: "email@domain.com"
     password: !secret franklinwh_password
     id: "100xxxxxxxxxxxx"
-    tou_reserve_pct: 20            # optional — battery reserve % for Time of Use
-    self_consumption_reserve_pct: 20  # optional — battery reserve % for Self Consumption
-    emergency_backup_reserve_pct: 100 # optional — battery reserve % for Emergency Backup
 ```
 
 This creates a single `select` entity — **FranklinWH Operating Mode** — with three options:
@@ -87,7 +85,29 @@ This creates a single `select` entity — **FranklinWH Operating Mode** — with
 | `Self Consumption` | Maximises use of solar / stored energy |
 | `Emergency Backup` | Keeps battery as full as possible for outage protection |
 
-When switching modes the battery reserve is set to the value configured above. The defaults match the FranklinWH app defaults (20 % for Time of Use / Self Consumption, 100 % for Emergency Backup). Set these to match your preferred reserves so they are preserved when switching modes from Home Assistant.
+When switching modes the battery reserve is read live from the gateway (via `getGatewayTouListV2`) and set accordingly. You no longer need to configure reserve percentages in your YAML — the values stored on your Agate are used automatically. The optional `tou_reserve_pct`, `self_consumption_reserve_pct`, and `emergency_backup_reserve_pct` config keys are still accepted as fallback defaults (used only before the first successful API fetch), but are no longer required.
+
+### Battery Reserve SOC
+
+The integration can expose per-mode battery reserve entities that let you read and adjust the reserve SOC for each operating mode — without switching modes.
+
+```yaml
+number:
+  - platform: franklin_wh
+    username: "email@domain.com"
+    password: !secret franklinwh_password
+    id: "100xxxxxxxxxxxx"
+```
+
+This creates three entities:
+
+| Entity | Description | Editable |
+|--------|-------------|----------|
+| FranklinWH Time of Use Reserve | Reserve SOC % for Time of Use mode | ✅ |
+| FranklinWH Self Consumption Reserve | Reserve SOC % for Self Consumption mode | ✅ |
+| FranklinWH Emergency Backup Reserve | Reserve SOC % for Emergency Backup mode | 🔒 Always 100% |
+
+Changes are written directly to the gateway via `updateSocV2` and take effect immediately without switching modes. The Emergency Backup reserve is always 100% (set by the FranklinWH platform) and is exposed as a read-only sensor.
 
 ### Smart Relays
 
@@ -121,15 +141,15 @@ After updating your configuration, restart Home Assistant to apply the changes.
 
 ### Advanced Configuration
 
-| Configuration Option              | Unit   | Description                                                                                              | sensor | switch | select |
-| --------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------| ------ | ------ | ------ |
-| `use_sn`                          | bool   | Use the gateway's SN as a prefix when creating entities                                                  |  ✅    |   ✅   |        |
-| `prefix`                          | string | Specify a prefix to be used when creating entities                                                       |  ✅    |   ✅   |   ✅   |
-| `update_interval`                 | time   | Period to update entities from franklinwh. Default 30s                                                   |  ✅    |   ✅   |   ✅   |
-| `tolerate_stale_data`             | bool   | Continue to show stale data on the dashboard for one cycle instead of showing the sensor unavailable     |  ✅    |        |        |
-| `tou_reserve_pct`                 | int    | Battery reserve % to set when switching to Time of Use. Default 20                                       |        |        |   ✅   |
-| `self_consumption_reserve_pct`    | int    | Battery reserve % to set when switching to Self Consumption. Default 20                                  |        |        |   ✅   |
-| `emergency_backup_reserve_pct`    | int    | Battery reserve % to set when switching to Emergency Backup. Default 100                                 |        |        |   ✅   |
+| Configuration Option              | Unit   | Description                                                                                              | sensor | switch | select | number |
+| --------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------| ------ | ------ | ------ | ------ |
+| `use_sn`                          | bool   | Use the gateway's SN as a prefix when creating entities                                                  |  ✅    |   ✅   |        |        |
+| `prefix`                          | string | Specify a prefix to be used when creating entities                                                       |  ✅    |   ✅   |   ✅   |   ✅   |
+| `update_interval`                 | time   | Period to update entities from franklinwh. Default 30s                                                   |  ✅    |   ✅   |   ✅   |   ✅   |
+| `tolerate_stale_data`             | bool   | Continue to show stale data on the dashboard for one cycle instead of showing the sensor unavailable     |  ✅    |        |        |        |
+| `tou_reserve_pct`                 | int    | _(Deprecated)_ Fallback battery reserve % for Time of Use before first API fetch. Default 20             |        |        |   ✅   |        |
+| `self_consumption_reserve_pct`    | int    | _(Deprecated)_ Fallback battery reserve % for Self Consumption before first API fetch. Default 20        |        |        |   ✅   |        |
+| `emergency_backup_reserve_pct`    | int    | _(Deprecated)_ Fallback battery reserve % for Emergency Backup before first API fetch. Default 100       |        |        |   ✅   |        |
 
 
 ## Available Entities
@@ -162,6 +182,14 @@ After updating your configuration, restart Home Assistant to apply the changes.
 | Entity Name                          | Description                               | Options                                                  |
 |--------------------------------------|-------------------------------------------|----------------------------------------------------------|
 | FranklinWH Operating Mode           | Current operating mode (read + write)     | Time of Use, Self Consumption, Emergency Backup          |
+
+### Number Entities
+
+| Entity Name                              | Description                                          | Unit | Editable |
+|------------------------------------------|------------------------------------------------------|------|----------|
+| FranklinWH Time of Use Reserve           | Battery reserve SOC for Time of Use mode             | %    | ✅       |
+| FranklinWH Self Consumption Reserve      | Battery reserve SOC for Self Consumption mode        | %    | ✅       |
+| FranklinWH Emergency Backup Reserve      | Battery reserve SOC for Emergency Backup mode        | %    | 🔒       |
 
 # Flipping sensors
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ This creates a single `select` entity — **FranklinWH Operating Mode** — with
 
 When switching modes the battery reserve is set to the value configured above. The defaults match the FranklinWH app defaults (20 % for Time of Use / Self Consumption, 100 % for Emergency Backup). Set these to match your preferred reserves so they are preserved when switching modes from Home Assistant.
 
-You can use this entity in automations, scripts, or Lovelace dashboards. For example, to automatically switch to Emergency Backup when a storm warning is issued, or back to Time of Use on a schedule.
-
 ### Smart Relays
 
 The integration can also manage smart relays, if you have them installed in your gateway. It is

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ After updating your configuration, restart Home Assistant to apply the changes.
 
 | Configuration Option              | Unit   | Description                                                                                              | sensor | switch | select |
 | --------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------| ------ | ------ | ------ |
-| `use_sn`                          | bool   | Use the gateway's SN as a prefix when creating entities                                                  |  ✅    |   ✅   |   ✅   |
+| `use_sn`                          | bool   | Use the gateway's SN as a prefix when creating entities                                                  |  ✅    |   ✅   |        |
 | `prefix`                          | string | Specify a prefix to be used when creating entities                                                       |  ✅    |   ✅   |   ✅   |
 | `update_interval`                 | time   | Period to update entities from franklinwh. Default 30s                                                   |  ✅    |   ✅   |   ✅   |
 | `tolerate_stale_data`             | bool   | Continue to show stale data on the dashboard for one cycle instead of showing the sensor unavailable     |  ✅    |        |        |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is a custom integration for [Home Assistant](https://www.home-assistant.io/
 - Generator and home load insights
 - Switch load and usage tracking
 - Support for V2L (Vehicle-to-Load) data
+- **Operating mode control** — switch between Time of Use, Self Consumption, and Emergency Backup
 
 ---
 
@@ -63,6 +64,33 @@ last good data until it's able to fetch more, substantially smoothing out the
 graphs. However, if accuracy is more important to you than consistency, you
 should not enable that flag.
 
+### Operating Mode
+
+The integration can expose an **Operating Mode** select entity that lets you switch your Agate between its three operating modes directly from Home Assistant — no app required.
+
+```yaml
+select:
+  - platform: franklin_wh
+    username: "email@domain.com"
+    password: !secret franklinwh_password
+    id: "100xxxxxxxxxxxx"
+    tou_reserve_pct: 20            # optional — battery reserve % for Time of Use
+    self_consumption_reserve_pct: 20  # optional — battery reserve % for Self Consumption
+    emergency_backup_reserve_pct: 100 # optional — battery reserve % for Emergency Backup
+```
+
+This creates a single `select` entity — **FranklinWH Operating Mode** — with three options:
+
+| Option | Description |
+|--------|-------------|
+| `Time of Use` | Optimises for time-of-use electricity tariffs |
+| `Self Consumption` | Maximises use of solar / stored energy |
+| `Emergency Backup` | Keeps battery as full as possible for outage protection |
+
+When switching modes the battery reserve is set to the value configured above. The defaults match the FranklinWH app defaults (20 % for Time of Use / Self Consumption, 100 % for Emergency Backup). Set these to match your preferred reserves so they are preserved when switching modes from Home Assistant.
+
+You can use this entity in automations, scripts, or Lovelace dashboards. For example, to automatically switch to Emergency Backup when a storm warning is issued, or back to Time of Use on a schedule.
+
 ### Smart Relays
 
 The integration can also manage smart relays, if you have them installed in your gateway. It is
@@ -95,12 +123,15 @@ After updating your configuration, restart Home Assistant to apply the changes.
 
 ### Advanced Configuration
 
-| Configuration Option         | Unit   | Description                                                               | sensor | switch |
-| ---------------------------- | ------ | --------------------------------------------------------------------------| ------ | ------ |
-| `use_sn`                     | bool   | Use the gateway's SN as a prefix when creating entities                   |  ✅    |   ✅   |
-| `prefix`                     | string | Specity a prefix to be used when creating entities                        |  ✅    |   ✅   |
-| `update_interval`            | time   | Period to update entities from franklinwh. Default 30s                    |  ✅    |   ✅   |
-| `tolerate_stale_data`        | bool   | Continue to show stale data on the dashboard for one cycle instead of showing the sensor unavailable                   |  ✅    |        |
+| Configuration Option              | Unit   | Description                                                                                              | sensor | switch | select |
+| --------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------| ------ | ------ | ------ |
+| `use_sn`                          | bool   | Use the gateway's SN as a prefix when creating entities                                                  |  ✅    |   ✅   |   ✅   |
+| `prefix`                          | string | Specify a prefix to be used when creating entities                                                       |  ✅    |   ✅   |   ✅   |
+| `update_interval`                 | time   | Period to update entities from franklinwh. Default 30s                                                   |  ✅    |   ✅   |   ✅   |
+| `tolerate_stale_data`             | bool   | Continue to show stale data on the dashboard for one cycle instead of showing the sensor unavailable     |  ✅    |        |        |
+| `tou_reserve_pct`                 | int    | Battery reserve % to set when switching to Time of Use. Default 20                                       |        |        |   ✅   |
+| `self_consumption_reserve_pct`    | int    | Battery reserve % to set when switching to Self Consumption. Default 20                                  |        |        |   ✅   |
+| `emergency_backup_reserve_pct`    | int    | Battery reserve % to set when switching to Emergency Backup. Default 100                                 |        |        |   ✅   |
 
 
 ## Available Entities
@@ -127,6 +158,12 @@ After updating your configuration, restart Home Assistant to apply the changes.
 | FranklinWH V2L Use                  | Power use via Vehicle-to-Load             | W         |
 | FranklinWH V2L Import               | Total energy drawn from V2L               | Wh        |
 | FranklinWH V2L Export               | Total energy delivered to V2L             | Wh        |
+
+### Select Entities
+
+| Entity Name                          | Description                               | Options                                                  |
+|--------------------------------------|-------------------------------------------|----------------------------------------------------------|
+| FranklinWH Operating Mode           | Current operating mode (read + write)     | Time of Use, Self Consumption, Emergency Backup          |
 
 # Flipping sensors
 

--- a/select.py
+++ b/select.py
@@ -82,6 +82,13 @@ _WORK_MODE_TO_API: dict[int, str] = {
     3: _API_EMERGENCY_BACKUP,
 }
 
+# Reverse mapping: UI option string → workMode int (for reserve lookups)
+_OPTION_TO_WORK_MODE: dict[str, int] = {
+    OPTION_TIME_OF_USE: 1,
+    OPTION_SELF_CONSUMPTION: 2,
+    OPTION_EMERGENCY_BACKUP: 3,
+}
+
 
 async def async_setup_platform(
     hass: HomeAssistant,
@@ -104,19 +111,24 @@ async def async_setup_platform(
     fetcher = franklinwh.TokenFetcher(username, password)
     client = franklinwh.Client(fetcher, gateway)
 
-    # Start with the config-supplied values as the initial defaults.  Once the
-    # coordinator performs its first successful fetch, get_tou_list() will
-    # overwrite these with the live values stored on the gateway, so users no
-    # longer need to set tou_reserve_pct / self_consumption_reserve_pct /
-    # emergency_backup_reserve_pct in their configuration.yaml.
-    reserves: dict[str, int] = {
-        OPTION_TIME_OF_USE: config["tou_reserve_pct"],
-        OPTION_SELF_CONSUMPTION: config["self_consumption_reserve_pct"],
-        OPTION_EMERGENCY_BACKUP: config["emergency_backup_reserve_pct"],
+    # Seed last-known reserves from config-supplied values (workMode int keys).
+    # After the first successful API fetch these are overwritten with live
+    # gateway data and carried forward across fallback-path polls, so
+    # async_select_option() always uses the most-recently-confirmed reserve
+    # rather than reverting to a stale YAML default.
+    _last_known_reserves: dict[int, int] = {
+        1: config["tou_reserve_pct"],
+        2: config["self_consumption_reserve_pct"],
+        3: config["emergency_backup_reserve_pct"],
     }
 
-    async def _update_data() -> str:
-        """Fetch the current operating mode (and live reserve SOC) from the gateway."""
+    async def _update_data() -> dict:
+        """Fetch operating mode and per-mode reserve SOC from the gateway.
+
+        Returns ``{"mode": <api_mode_str>, "reserves": {workMode: soc, ...}}``.
+        On the fallback path the reserves key carries the last successfully
+        fetched values so async_select_option() always has consistent SOC data.
+        """
         _LOGGER.debug("Fetching operating mode from FranklinWH")
 
         # Primary: getGatewayTouListV2 returns both the current mode and the
@@ -141,21 +153,17 @@ async def async_setup_platform(
             if work_mode is not None:
                 mode_name = _WORK_MODE_TO_API.get(int(work_mode))
                 if mode_name is not None:
-                    # Update the shared reserves dict in-place so the entity's
-                    # async_select_option() automatically picks up live values.
+                    # Persist the freshly-fetched reserves so they survive a
+                    # later fallback-path poll.
                     for wm_int, soc in tou.get("reserves", {}).items():
-                        option = _API_TO_OPTION.get(
-                            _WORK_MODE_TO_API.get(int(wm_int), ""), ""
-                        )
-                        if option:
-                            reserves[option] = int(soc)
+                        _last_known_reserves[int(wm_int)] = int(soc)
                     _LOGGER.debug(
                         "get_tou_list(): workMode=%s → %s, reserves=%s",
                         work_mode,
                         mode_name,
-                        reserves,
+                        _last_known_reserves,
                     )
-                    return mode_name
+                    return {"mode": mode_name, "reserves": dict(_last_known_reserves)}
             raise UpdateFailed(f"Unrecognised current_work_mode: {work_mode!r}")
         except UpdateFailed:
             raise
@@ -177,8 +185,8 @@ async def async_setup_platform(
 
         # Fallback: get_composite_info() returns currentWorkMode (1/2/3) using
         # the same encoding as Mode.workMode and is reliable across firmware.
-        # Reserves are not updated in this path — the config/default values
-        # (or the last successfully fetched values) remain in effect.
+        # Reserves are not updated here — _last_known_reserves carries the most
+        # recently fetched values (or YAML defaults on first boot).
         try:
             composite = await client.get_composite_info()
             work_mode = composite.get("currentWorkMode")
@@ -186,11 +194,12 @@ async def async_setup_platform(
                 mode_name = _WORK_MODE_TO_API.get(int(work_mode))
                 if mode_name is not None:
                     _LOGGER.debug(
-                        "currentWorkMode=%s → mode %s (reserves unchanged)",
+                        "currentWorkMode=%s → mode %s (reserves from last good fetch: %s)",
                         work_mode,
                         mode_name,
+                        _last_known_reserves,
                     )
-                    return mode_name
+                    return {"mode": mode_name, "reserves": dict(_last_known_reserves)}
             raise UpdateFailed(f"Unrecognised currentWorkMode: {work_mode!r}")
         except UpdateFailed:
             raise
@@ -201,7 +210,7 @@ async def async_setup_platform(
         except Exception as e:  # noqa: BLE001
             raise UpdateFailed(f"Error reading operating mode: {e}") from e
 
-    coordinator = DataUpdateCoordinator[str](
+    coordinator = DataUpdateCoordinator[dict](
         hass,
         _LOGGER,
         name="franklinwh_mode",
@@ -213,11 +222,11 @@ async def async_setup_platform(
     # Initial fetch so the entity is available immediately on startup
     await coordinator.async_refresh()
 
-    async_add_entities([OperatingModeSelect(coordinator, prefix, gateway, client, reserves)])
+    async_add_entities([OperatingModeSelect(coordinator, prefix, gateway, client)])
 
 
 class OperatingModeSelect(
-    CoordinatorEntity[DataUpdateCoordinator[str]],
+    CoordinatorEntity[DataUpdateCoordinator[dict]],
     SelectEntity,
 ):
     """Select entity exposing the FranklinWH operating mode."""
@@ -230,14 +239,12 @@ class OperatingModeSelect(
         prefix: str,
         gateway: str,
         client: franklinwh.Client,
-        reserves: dict[str, int],
     ) -> None:
         """Initializer."""
         super().__init__(coordinator)
         self._attr_name = f"{prefix} Operating Mode"
         self._client = client
         self._attr_unique_id = gateway + "_operating_mode"
-        self._reserves = reserves
         self._optimistic_option: str | None = None
 
     @callback
@@ -261,7 +268,7 @@ class OperatingModeSelect(
             return self._optimistic_option
         if self.coordinator.data is None:
             return None
-        return _API_TO_OPTION.get(self.coordinator.data)
+        return _API_TO_OPTION.get(self.coordinator.data["mode"])
 
     async def async_select_option(self, option: str) -> None:
         """Change the operating mode."""
@@ -269,8 +276,21 @@ class OperatingModeSelect(
             _LOGGER.error("Unknown operating mode option: %s", option)
             return
 
-        soc = self._reserves[option]
-        mode_obj = _OPTION_TO_MODE_FACTORY[option](soc=soc)
+        if self.coordinator.data is None:
+            _LOGGER.error("Cannot switch mode: coordinator data is unavailable")
+            return
+
+        work_mode = _OPTION_TO_WORK_MODE[option]
+        soc = self.coordinator.data["reserves"].get(work_mode)
+        if soc is None:
+            _LOGGER.error(
+                "No reserve data for %s (workMode=%s) in coordinator data",
+                option,
+                work_mode,
+            )
+            return
+
+        mode_obj = _OPTION_TO_MODE_FACTORY[option](soc=int(soc))
 
         _LOGGER.info(
             "Setting FranklinWH operating mode to: %s (reserve=%s%%)", option, soc

--- a/select.py
+++ b/select.py
@@ -36,7 +36,6 @@ PLATFORM_SCHEMA = SELECT_PLATFORM_SCHEMA.extend(
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Required(CONF_ID): cv.string,
-        vol.Optional("use_sn", default=False): cv.boolean,
         vol.Optional("prefix", default=False): cv.string,
         vol.Optional(
             "update_interval", default=DEFAULT_UPDATE_INTERVAL
@@ -95,12 +94,6 @@ async def async_setup_platform(
     password: str = config[CONF_PASSWORD]
     gateway: str = config[CONF_ID]
     update_interval: timedelta = config["update_interval"]
-
-    # TODO(richo) why does it string the default value
-    if config["use_sn"] and config["use_sn"] != "False":
-        unique_id = gateway
-    else:
-        unique_id = None
 
     # TODO(richo) why does it string the default value
     if config["prefix"] and config["prefix"] != "False":
@@ -222,8 +215,8 @@ class OperatingModeSelect(
             _LOGGER.error("Unknown operating mode option: %s", option)
             return
 
-        soc = self._reserves.get(option)
-        mode_obj = _OPTION_TO_MODE_FACTORY[option](soc=soc) if soc is not None else _OPTION_TO_MODE_FACTORY[option]()
+        soc = self._reserves[option]
+        mode_obj = _OPTION_TO_MODE_FACTORY[option](soc=soc)
 
         _LOGGER.info(
             "Setting FranklinWH operating mode to: %s (reserve=%s%%)", option, soc

--- a/select.py
+++ b/select.py
@@ -1,0 +1,242 @@
+"""Select platform for FranklinWH — operating mode control."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+import franklinwh
+import httpx
+import voluptuous as vol
+
+from homeassistant.components.select import (
+    PLATFORM_SCHEMA as SELECT_PLATFORM_SCHEMA,
+    SelectEntity,
+)
+from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
+
+_LOGGER = logging.getLogger(__name__)
+DEFAULT_UPDATE_INTERVAL = 30
+
+DEFAULT_TOU_RESERVE = 20
+DEFAULT_SELF_RESERVE = 20
+DEFAULT_EMERGENCY_RESERVE = 100
+
+PLATFORM_SCHEMA = SELECT_PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_ID): cv.string,
+        vol.Optional("use_sn", default=False): cv.boolean,
+        vol.Optional("prefix", default=False): cv.string,
+        vol.Optional(
+            "update_interval", default=DEFAULT_UPDATE_INTERVAL
+        ): cv.time_period,
+        vol.Optional("tou_reserve_pct", default=DEFAULT_TOU_RESERVE): cv.positive_int,
+        vol.Optional("self_consumption_reserve_pct", default=DEFAULT_SELF_RESERVE): cv.positive_int,
+        vol.Optional("emergency_backup_reserve_pct", default=DEFAULT_EMERGENCY_RESERVE): cv.positive_int,
+    }
+)
+
+# Human-readable option strings shown in the Home Assistant UI
+OPTION_TIME_OF_USE = "Time of Use"
+OPTION_SELF_CONSUMPTION = "Self Consumption"
+OPTION_EMERGENCY_BACKUP = "Emergency Backup"
+
+MODE_OPTIONS = [OPTION_TIME_OF_USE, OPTION_SELF_CONSUMPTION, OPTION_EMERGENCY_BACKUP]
+
+# franklinwh library internal mode strings (matches franklinwh.client.MODE_*)
+# Defined locally so we don't import private symbols not in franklinwh.__all__
+_API_TIME_OF_USE = "time_of_use"
+_API_SELF_CONSUMPTION = "self_consumption"
+_API_EMERGENCY_BACKUP = "emergency_backup"
+
+# Map from the franklinwh library's internal mode strings → UI option strings
+_API_TO_OPTION: dict[str, str] = {
+    _API_TIME_OF_USE: OPTION_TIME_OF_USE,
+    _API_SELF_CONSUMPTION: OPTION_SELF_CONSUMPTION,
+    _API_EMERGENCY_BACKUP: OPTION_EMERGENCY_BACKUP,
+}
+
+# Map from UI option strings → Mode factory callables
+_OPTION_TO_MODE_FACTORY = {
+    OPTION_TIME_OF_USE: franklinwh.Mode.time_of_use,
+    OPTION_SELF_CONSUMPTION: franklinwh.Mode.self_consumption,
+    OPTION_EMERGENCY_BACKUP: franklinwh.Mode.emergency_backup,
+}
+
+# Map from get_composite_info() currentWorkMode (1/2/3) → internal mode string.
+# Uses the same encoding as Mode.workMode; the runingMode field in
+# _switch_status() is not reliable for mode detection across firmware versions.
+_WORK_MODE_TO_API: dict[int, str] = {
+    1: _API_TIME_OF_USE,
+    2: _API_SELF_CONSUMPTION,
+    3: _API_EMERGENCY_BACKUP,
+}
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the select platform."""
+    username: str = config[CONF_USERNAME]
+    password: str = config[CONF_PASSWORD]
+    gateway: str = config[CONF_ID]
+    update_interval: timedelta = config["update_interval"]
+
+    # TODO(richo) why does it string the default value
+    if config["use_sn"] and config["use_sn"] != "False":
+        unique_id = gateway
+    else:
+        unique_id = None
+
+    # TODO(richo) why does it string the default value
+    if config["prefix"] and config["prefix"] != "False":
+        prefix = config["prefix"]
+    else:
+        prefix = "FranklinWH"
+
+    fetcher = franklinwh.TokenFetcher(username, password)
+    client = franklinwh.Client(fetcher, gateway)
+
+    reserves: dict[str, int] = {
+        OPTION_TIME_OF_USE: config["tou_reserve_pct"],
+        OPTION_SELF_CONSUMPTION: config["self_consumption_reserve_pct"],
+        OPTION_EMERGENCY_BACKUP: config["emergency_backup_reserve_pct"],
+    }
+
+    async def _update_data() -> str:
+        """Fetch the current operating mode from the gateway."""
+        _LOGGER.debug("Fetching operating mode from FranklinWH")
+
+        # Try the library's get_mode() first
+        try:
+            mode_name, _ = await client.get_mode()
+            return mode_name
+        except franklinwh.client.DeviceTimeoutException as e:
+            raise UpdateFailed(f"Device timeout: {e}") from e
+        except franklinwh.client.GatewayOfflineException as e:
+            raise UpdateFailed(f"Gateway offline: {e}") from e
+        except franklinwh.client.AccountLockedException as e:
+            raise UpdateFailed(f"Account locked: {e}") from e
+        except franklinwh.client.InvalidCredentialsException as e:
+            raise UpdateFailed(f"Invalid credentials: {e}") from e
+        except Exception as e:  # noqa: BLE001
+            # get_mode() raises KeyError when runingMode is not in MODE_MAP —
+            # observed on some firmware versions. Fall through to the fallback.
+            _LOGGER.debug(
+                "get_mode() raised %s, falling back to composite info",
+                type(e).__name__,
+            )
+
+        # Fallback: get_composite_info() returns currentWorkMode (1/2/3) using
+        # the same encoding as Mode.workMode and is reliable across firmware.
+        try:
+            composite = await client.get_composite_info()
+            work_mode = composite.get("currentWorkMode")
+            if work_mode is not None:
+                mode_name = _WORK_MODE_TO_API.get(int(work_mode))
+                if mode_name is not None:
+                    _LOGGER.debug(
+                        "currentWorkMode=%s → mode %s", work_mode, mode_name
+                    )
+                    return mode_name
+            raise UpdateFailed(f"Unrecognised currentWorkMode: {work_mode!r}")
+        except UpdateFailed:
+            raise
+        except franklinwh.client.DeviceTimeoutException as e:
+            raise UpdateFailed(f"Device timeout: {e}") from e
+        except franklinwh.client.GatewayOfflineException as e:
+            raise UpdateFailed(f"Gateway offline: {e}") from e
+        except Exception as e:  # noqa: BLE001
+            raise UpdateFailed(f"Error reading operating mode: {e}") from e
+
+    coordinator = DataUpdateCoordinator[str](
+        hass,
+        _LOGGER,
+        name="franklinwh_mode",
+        update_method=_update_data,
+        update_interval=update_interval,
+        always_update=False,
+    )
+
+    # Initial fetch so the entity is available immediately on startup
+    await coordinator.async_refresh()
+
+    async_add_entities([OperatingModeSelect(coordinator, prefix, gateway, client, reserves)])
+
+
+class OperatingModeSelect(
+    CoordinatorEntity[DataUpdateCoordinator[str]],
+    SelectEntity,
+):
+    """Select entity exposing the FranklinWH operating mode."""
+
+    _attr_options = MODE_OPTIONS
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        prefix: str,
+        gateway: str,
+        client: franklinwh.Client,
+        reserves: dict[str, int],
+    ) -> None:
+        """Initializer."""
+        super().__init__(coordinator)
+        self._attr_name = f"{prefix} Operating Mode"
+        self._client = client
+        self._attr_unique_id = gateway + "_operating_mode"
+        self._reserves = reserves
+
+    @property
+    def available(self) -> bool:
+        """Is the entity available?"""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the currently active operating mode."""
+        if self.coordinator.data is None:
+            return None
+        return _API_TO_OPTION.get(self.coordinator.data)
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the operating mode."""
+        if option not in _OPTION_TO_MODE_FACTORY:
+            _LOGGER.error("Unknown operating mode option: %s", option)
+            return
+
+        soc = self._reserves.get(option)
+        mode_obj = _OPTION_TO_MODE_FACTORY[option](soc=soc) if soc is not None else _OPTION_TO_MODE_FACTORY[option]()
+
+        _LOGGER.info(
+            "Setting FranklinWH operating mode to: %s (reserve=%s%%)", option, soc
+        )
+        try:
+            await self._client.set_mode(mode_obj)
+        except httpx.ReadTimeout:
+            # The API frequently times out even when the command succeeds.
+            # The coordinator refresh below will confirm the actual state.
+            _LOGGER.warning(
+                "set_mode(%s) timed out — command may still have been applied",
+                option,
+            )
+
+        # Refresh so the entity state reflects the change immediately
+        await self.coordinator.async_refresh()

--- a/select.py
+++ b/select.py
@@ -104,6 +104,11 @@ async def async_setup_platform(
     fetcher = franklinwh.TokenFetcher(username, password)
     client = franklinwh.Client(fetcher, gateway)
 
+    # Start with the config-supplied values as the initial defaults.  Once the
+    # coordinator performs its first successful fetch, get_tou_list() will
+    # overwrite these with the live values stored on the gateway, so users no
+    # longer need to set tou_reserve_pct / self_consumption_reserve_pct /
+    # emergency_backup_reserve_pct in their configuration.yaml.
     reserves: dict[str, int] = {
         OPTION_TIME_OF_USE: config["tou_reserve_pct"],
         OPTION_SELF_CONSUMPTION: config["self_consumption_reserve_pct"],
@@ -111,13 +116,49 @@ async def async_setup_platform(
     }
 
     async def _update_data() -> str:
-        """Fetch the current operating mode from the gateway."""
+        """Fetch the current operating mode (and live reserve SOC) from the gateway."""
         _LOGGER.debug("Fetching operating mode from FranklinWH")
 
-        # Try the library's get_mode() first
+        # Primary: getGatewayTouListV2 returns both the current mode and the
+        # per-mode reserve SOC percentages stored on the gateway.  Inlined here
+        # so it works with older franklinwh PyPI versions that predate
+        # client.get_tou_list().
+        async def _get_tou_list():
+            url = client.url_base + "hes-gateway/terminal/tou/getGatewayTouListV2"
+            result = (await client._post(url, "", params={"showType": "1"}))["result"]
+            current_id = result["currendId"]
+            res: dict[int, float] = {}
+            current_wm: int | None = None
+            for entry in result["list"]:
+                res[entry["workMode"]] = entry["soc"]
+                if entry["id"] == current_id:
+                    current_wm = entry["workMode"]
+            return {"reserves": res, "current_work_mode": current_wm}
+
         try:
-            mode_name, _ = await client.get_mode()
-            return mode_name
+            tou = await _get_tou_list()
+            work_mode = tou.get("current_work_mode")
+            if work_mode is not None:
+                mode_name = _WORK_MODE_TO_API.get(int(work_mode))
+                if mode_name is not None:
+                    # Update the shared reserves dict in-place so the entity's
+                    # async_select_option() automatically picks up live values.
+                    for wm_int, soc in tou.get("reserves", {}).items():
+                        option = _API_TO_OPTION.get(
+                            _WORK_MODE_TO_API.get(int(wm_int), ""), ""
+                        )
+                        if option:
+                            reserves[option] = int(soc)
+                    _LOGGER.debug(
+                        "get_tou_list(): workMode=%s → %s, reserves=%s",
+                        work_mode,
+                        mode_name,
+                        reserves,
+                    )
+                    return mode_name
+            raise UpdateFailed(f"Unrecognised current_work_mode: {work_mode!r}")
+        except UpdateFailed:
+            raise
         except franklinwh.client.DeviceTimeoutException as e:
             raise UpdateFailed(f"Device timeout: {e}") from e
         except franklinwh.client.GatewayOfflineException as e:
@@ -127,15 +168,17 @@ async def async_setup_platform(
         except franklinwh.client.InvalidCredentialsException as e:
             raise UpdateFailed(f"Invalid credentials: {e}") from e
         except Exception as e:  # noqa: BLE001
-            # get_mode() raises KeyError when runingMode is not in MODE_MAP —
-            # observed on some firmware versions. Fall through to the fallback.
+            # get_tou_list() is a newer endpoint; some firmware versions may not
+            # support it.  Fall through to the get_composite_info() fallback.
             _LOGGER.debug(
-                "get_mode() raised %s, falling back to composite info",
+                "get_tou_list() raised %s, falling back to composite info",
                 type(e).__name__,
             )
 
         # Fallback: get_composite_info() returns currentWorkMode (1/2/3) using
         # the same encoding as Mode.workMode and is reliable across firmware.
+        # Reserves are not updated in this path — the config/default values
+        # (or the last successfully fetched values) remain in effect.
         try:
             composite = await client.get_composite_info()
             work_mode = composite.get("currentWorkMode")
@@ -143,7 +186,9 @@ async def async_setup_platform(
                 mode_name = _WORK_MODE_TO_API.get(int(work_mode))
                 if mode_name is not None:
                     _LOGGER.debug(
-                        "currentWorkMode=%s → mode %s", work_mode, mode_name
+                        "currentWorkMode=%s → mode %s (reserves unchanged)",
+                        work_mode,
+                        mode_name,
                     )
                     return mode_name
             raise UpdateFailed(f"Unrecognised currentWorkMode: {work_mode!r}")

--- a/select.py
+++ b/select.py
@@ -14,7 +14,7 @@ from homeassistant.components.select import (
     SelectEntity,
 )
 from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -193,6 +193,13 @@ class OperatingModeSelect(
         self._client = client
         self._attr_unique_id = gateway + "_operating_mode"
         self._reserves = reserves
+        self._optimistic_option: str | None = None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Clear optimistic state once the coordinator confirms the actual mode."""
+        self._optimistic_option = None
+        super()._handle_coordinator_update()
 
     @property
     def available(self) -> bool:
@@ -205,6 +212,8 @@ class OperatingModeSelect(
     @property
     def current_option(self) -> str | None:
         """Return the currently active operating mode."""
+        if self._optimistic_option is not None:
+            return self._optimistic_option
         if self.coordinator.data is None:
             return None
         return _API_TO_OPTION.get(self.coordinator.data)
@@ -221,6 +230,13 @@ class OperatingModeSelect(
         _LOGGER.info(
             "Setting FranklinWH operating mode to: %s (reserve=%s%%)", option, soc
         )
+
+        # Optimistically reflect the new mode in the UI immediately, before the
+        # API call completes. _handle_coordinator_update() clears this once the
+        # coordinator confirms the actual state from the gateway.
+        self._optimistic_option = option
+        self.async_write_ha_state()
+
         try:
             await self._client.set_mode(mode_obj)
         except httpx.ReadTimeout:
@@ -231,5 +247,5 @@ class OperatingModeSelect(
                 option,
             )
 
-        # Refresh so the entity state reflects the change immediately
+        # Refresh to confirm the actual state and clear the optimistic value.
         await self.coordinator.async_refresh()


### PR DESCRIPTION
Adds a `select` platform exposing the FranklinWH Agate's operating mode
(Time of Use / Self Consumption / Emergency Backup) as a Home Assistant
select entity, allowing mode switching directly from HA.

As I got into this it was apparent that it was outside my programming
abilities — for full disclosure, I used Claude.ai to help develop this
and I don't fully understand all of the code.

## Configuration

```yaml
select:
  - platform: franklin_wh
    username: "email@domain.com"
    password: !secret franklinwh_password
    id: "100xxxxxxxxxxxx"
    tou_reserve_pct: 20            # optional, default 20
    self_consumption_reserve_pct: 20  # optional, default 20
    emergency_backup_reserve_pct: 100 # optional, default 100

Implementation notes

Reading the mode: get_mode() fails on firmware versions where
runingMode is not in the library's MODE_MAP (values like 21669 and
83132 observed in the field). The fallback uses get_composite
currentWorkMode, which uses the same 1/2/3 encoding as Mode.workMode
and is reliable across all tested firmware versions.

Writing the mode: set_mode() consistently raises
httpx.ReadTimeout even when the gateway accepts the command. This is
caught and treated as a probable success; the coordinator ref
follows confirms the actual new state.

Optimistic UI update: The entity state is updated immediately when
the user selects a mode, before set_mode() completes. This pr
the UI appearing frozen during the timeout. _handle_coordinator_update
clears the optimistic value once the coordinator confirms the

Battery reserve: The soc parameter passed to set_mode() contr
the battery reserve, but no API endpoint returns the current value — the
gateway does not expose it in _switch_status(), _status(), or
get_composite_info(). Three optional config keys let users declare
their preferred per-mode reserves so they are preserved across mode
switches from HA.

runtimeData['name'] in getDeviceCompositeInfo is the tariff
profile name (e.g. "Free power"), not the operating mode — it must not
be used for mode detection.


Tested on firmware V12R02B20D00_250701 / protocol V1.11.01,
