### PR TITLE
Wrap get_stats() in asyncio.timeout so a hung request can't stop updates forever

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -39,6 +39,7 @@ from homeassistant.helpers.update_coordinator import (
 
 _LOGGER = logging.getLogger(__name__)
 DEFAULT_UPDATE_INTERVAL = 30
+FETCH_TIMEOUT = 30
 
 PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
     {
@@ -136,7 +137,17 @@ async def async_setup_platform(
                 _LOGGER.warning("Trying again")
                 await asyncio.sleep(retry_delay)
             try:
-                data = await client.get_stats()
+                # Bound the fetch: without a timeout, a single hung request
+                # stops the DataUpdateCoordinator forever (the next poll is
+                # only scheduled once this one finishes) with nothing logged.
+                async with asyncio.timeout(FETCH_TIMEOUT):
+                    data = await client.get_stats()
+            except TimeoutError as e:
+                _LOGGER.warning(
+                    "Error getting data from FranklinWH - request hung for %ss: %s",
+                    FETCH_TIMEOUT,
+                    e,
+                )
             except franklinwh.client.DeviceTimeoutException as e:
                 _LOGGER.warning(
                     "Error getting data from FranklinWH - Device Timeout: %s", e


### PR DESCRIPTION
Fixes #84.

## Problem

`_update_data()` awaits `client.get_stats()` with no bound. If the request never completes (hung connection/stream — hit this in production on HA 2026.7.2 with the HTTP/2 client path), the coordinator refresh never returns:

- `DataUpdateCoordinator` only schedules the next poll after the current one finishes, so polling stops permanently;
- the debouncer refresh lock is held for the duration, so `homeassistant.update_entity` can't revive it;
- no exception handler runs, so nothing is logged.

With `tolerate_stale_data: true` every entity then keeps its last value and stays available indefinitely — in my case all 20 entities sat frozen for 15+ hours (SoC pinned at 99.7% while the battery cycled) with zero `franklin_wh` log lines. Only a core restart recovers.

## Fix

Wrap the fetch in `async with asyncio.timeout(FETCH_TIMEOUT)` (30s, matching the default update interval) and catch `TimeoutError` alongside the other per-attempt failures, so a hang flows into the existing retry → stale-cache → `UpdateFailed` path and gets logged like every other failure mode.

Running this in production since 2026-07-18 — normal polling unaffected, and warnings now appear if a request hangs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)